### PR TITLE
#as-plugin - Support sync same way as TS Plugin

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "@supernovaio/cli",
-    "version": "0.9.26",
+    "version": "0.9.29",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "@supernovaio/cli",
-            "version": "0.9.26",
+            "version": "0.9.29",
             "license": "MIT",
             "dependencies": {
                 "@oclif/core": "^1",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@supernovaio/cli",
     "description": "Supernova.io Command Line Interface",
-    "version": "0.9.26",
+    "version": "0.9.29",
     "author": "Supernova.io",
     "homepage": "https://supernova.io/",
     "keywords": [

--- a/src/utils/figma-tokens-data-loader.ts
+++ b/src/utils/figma-tokens-data-loader.ts
@@ -1,259 +1,268 @@
 import {
-    DTPluginToSupernovaMap,
-    DTPluginToSupernovaSettings,
-    DTPluginToSupernovaMapPack,
-    DTPluginToSupernovaMappingFile,
-    DTPluginToSupernovaMapType
-  } from "@supernovaio/supernova-sdk"
-  import * as fs from 'fs'
-  const path = require('path')
+  DTPluginToSupernovaMap,
+  DTPluginToSupernovaSettings,
+  DTPluginToSupernovaMapPack,
+  DTPluginToSupernovaMappingFile,
+  DTPluginToSupernovaMapType
+} from "@supernovaio/supernova-sdk"
+import * as fs from 'fs'
+const path = require('path')
 
 export class FigmaTokensDataLoader {
 
-    /** Load token definitions from path */
-    async loadTokensFromPath(pathToFile: string): Promise<object> {
-      try {
-        if (!(fs.existsSync(pathToFile) && fs.lstatSync(pathToFile).isFile())) {
-          throw Error(
-            `Provided token file directory ${pathToFile} is not a file or doesn't exist`
-          )
-        }
-  
-        let definition = fs.readFileSync(pathToFile, 'utf8')
-        let parsedDefinition = this.parseDefinition(definition)
-        return parsedDefinition
-      } catch (error) {
-        throw new Error('Unable to load JSON definition file: ' + error)
+  /** Load token definitions from path */
+  async loadTokensFromPath(pathToFile: string): Promise<object> {
+    try {
+      if (!(fs.existsSync(pathToFile) && fs.lstatSync(pathToFile).isFile())) {
+        throw Error(
+          `Provided token file directory ${pathToFile} is not a file or doesn't exist`
+        )
       }
+
+      let definition = fs.readFileSync(pathToFile, 'utf8')
+      let parsedDefinition = this.parseDefinition(definition)
+      return parsedDefinition
+    } catch (error) {
+      throw new Error('Unable to load JSON definition file: ' + error)
     }
-  
-    async loadTokensFromDirectory(pathToDirectory: string, settingsPath: string): Promise<object> {
-      try {
-        let fullStructuredObject: Record<string, any> = {}
-  
-        if (!(fs.existsSync(pathToDirectory) && fs.lstatSync(pathToDirectory).isDirectory())) {
-          throw new Error(
-            `Provided data directory ${pathToDirectory} is not a directory or doesn't exist`
-          )
-        }
-  
-        let jsonPaths = this.getAllJSONFiles(pathToDirectory)
-        for (let path of jsonPaths) {
-          if (path.endsWith('json') && path !== settingsPath && !path.includes('$')) {
-            let result = await this.loadObjectFile(path)
-            if (typeof result === 'object') {
-              // let name = this.getFileNameWithoutExtension(path)
-              let name = this.getSetKey(path, pathToDirectory)
-              fullStructuredObject[name] = result
-            }
+  }
+
+  async loadTokensFromDirectory(pathToDirectory: string, settingsPath: string): Promise<object> {
+    try {
+      let fullStructuredObject: Record<string, any> = {}
+
+      if (!(fs.existsSync(pathToDirectory) && fs.lstatSync(pathToDirectory).isDirectory())) {
+        throw new Error(
+          `Provided data directory ${pathToDirectory} is not a directory or doesn't exist`
+        )
+      }
+
+      let jsonPaths = this.getAllJSONFiles(pathToDirectory)
+      for (let path of jsonPaths) {
+        if (path.endsWith('json') && path !== settingsPath && !path.includes('$')) {
+          let result = await this.loadObjectFile(path)
+          if (typeof result === 'object') {
+            // let name = this.getFileNameWithoutExtension(path)
+            let name = this.getSetKey(path, pathToDirectory)
+            fullStructuredObject[name] = result
           }
         }
-  
-        // Try to load themes, if any
-        let themePath = pathToDirectory + '/' + '$themes.json'
-        if (fs.existsSync(themePath)) {
-          let themes = await this.loadObjectFile(themePath)
-          fullStructuredObject['$themes'] = themes
-        }
-  
-        // Try to load metadata, if any
-        let metadataPath = pathToDirectory + '/' + '$metadata.json'
-        if (fs.existsSync(metadataPath)) {
-          let metadata = await this.loadObjectFile(metadataPath)
-          fullStructuredObject['$metadata'] = metadata
-        }
-  
-        return fullStructuredObject
-      } catch (error) {
-        throw new Error('Unable to load JSON definition file: ' + error)
       }
-    }
-  
-    private getAllJSONFiles(dir: string): string[] {
-      const files = fs.readdirSync(dir)
-      const jsonFiles = []
-  
-      for (const file of files) {
-        const filePath = `${dir}/${file}`
-        const fileStat = fs.statSync(filePath)
-  
-        if (fileStat.isDirectory()) {
-          jsonFiles.push(...this.getAllJSONFiles(filePath))
-        } else if (fileStat.isFile() && filePath.endsWith('.json')) {
-          jsonFiles.push(filePath)
-        }
+
+      // Try to load themes, if any
+      let themePath = pathToDirectory + '/' + '$themes.json'
+      if (fs.existsSync(themePath)) {
+        let themes = await this.loadObjectFile(themePath)
+        fullStructuredObject['$themes'] = themes
       }
-  
-      return jsonFiles
+
+      // Try to load metadata, if any
+      let metadataPath = pathToDirectory + '/' + '$metadata.json'
+      if (fs.existsSync(metadataPath)) {
+        let metadata = await this.loadObjectFile(metadataPath)
+        fullStructuredObject['$metadata'] = metadata
+      }
+
+      return fullStructuredObject
+    } catch (error) {
+      throw new Error('Unable to load JSON definition file: ' + error)
     }
-  
-    private getFileNameWithoutExtension(filePath: string): string {
+  }
+
+  private getAllJSONFiles(dir: string): string[] {
+    const files = fs.readdirSync(dir)
+    const jsonFiles = []
+
+    for (const file of files) {
+      const filePath = `${dir}/${file}`
       const fileStat = fs.statSync(filePath)
-  
-      if (!fileStat.isFile()) {
-        throw new Error(`${filePath} is not a file`)
-      }
-  
-      return path.basename(filePath, path.extname(filePath))
-    }
-  
-    private getSetKey(jsonFilePath: string, loadedDirectory: string): string {
-      return jsonFilePath.substring(loadedDirectory.length + 1, jsonFilePath.length - 5)
-    }
-  
-    loadConfigFromPath(
-      pathToFile: string
-    ): {
-      mapping: DTPluginToSupernovaMapPack
-      settings: DTPluginToSupernovaSettings
-    } {
-      try {
-        if (!(fs.existsSync(pathToFile) && fs.lstatSync(pathToFile).isFile())) {
-          throw new Error(
-            `Provided configuration file directory ${pathToFile} is not a file or doesn't exist`
-          )
-        }
-  
-        let definition = fs.readFileSync(pathToFile, 'utf8')
-        let parsedDefinition = this.parseDefinition(definition) as DTPluginToSupernovaMappingFile
-        this.weakValidateMapping(parsedDefinition)
-        return this.processFileToMapping(parsedDefinition)
-      } catch (error) {
-        throw new Error('Unable to load JSON definition file: ' + error)
+
+      if (fileStat.isDirectory()) {
+        jsonFiles.push(...this.getAllJSONFiles(filePath))
+      } else if (fileStat.isFile() && filePath.endsWith('.json')) {
+        jsonFiles.push(filePath)
       }
     }
-  
-    private weakValidateMapping(mapping: DTPluginToSupernovaMappingFile) {
-      if (
-        !mapping.hasOwnProperty('mode') ||
-        typeof mapping.mode !== 'string' ||
-        (mapping.mode !== 'multi-file' && mapping.mode !== 'single-file')
-      ) {
+
+    return jsonFiles
+  }
+
+  private getFileNameWithoutExtension(filePath: string): string {
+    const fileStat = fs.statSync(filePath)
+
+    if (!fileStat.isFile()) {
+      throw new Error(`${filePath} is not a file`)
+    }
+
+    return path.basename(filePath, path.extname(filePath))
+  }
+
+  private getSetKey(jsonFilePath: string, loadedDirectory: string): string {
+    return jsonFilePath.substring(loadedDirectory.length + 1, jsonFilePath.length - 5)
+  }
+
+  loadConfigFromPath(
+    pathToFile: string
+  ): {
+    mapping: DTPluginToSupernovaMapPack
+    settings: DTPluginToSupernovaSettings
+  } {
+    try {
+      let parsedDefinition = this.loadConfigFromPathAsIs(pathToFile) as DTPluginToSupernovaMappingFile
+      this.weakValidateMapping(parsedDefinition)
+      return this.processFileToMapping(parsedDefinition)
+    } catch (error) {
+      throw new Error('Unable to load JSON definition file: ' + error)
+    }
+  }
+
+  loadConfigFromPathAsIs(pathToFile: string): DTPluginToSupernovaMappingFile {
+    try {
+      if (!(fs.existsSync(pathToFile) && fs.lstatSync(pathToFile).isFile())) {
         throw new Error(
-          'Unable to load mapping file: `mode` must be provided [single-file or multi-file]`'
+          `Provided configuration file directory ${pathToFile} is not a file or doesn't exist`
         )
       }
-      if (!mapping.mapping || !(mapping.mapping instanceof Array)) {
-        throw new Error('Unable to load mapping file: `mapping` key must be present and array.')
-      }
-      let mapPack = mapping.mapping
-      for (let map of mapPack) {
-        if (typeof map !== 'object') {
-          throw new Error('Unable to load mapping file: `mapping` must contain objects only')
-        }
-        if (!map.tokenSets && !map.tokensTheme) {
-          throw new Error(
-            'Unable to load mapping file: `mapping` must contain either `tokensTheme` or `tokenSets`'
-          )
-        }
-        if (map.tokenSets && map.tokensTheme) {
-          throw new Error(
-            'Unable to load mapping file: `mapping` must not contain both `tokensTheme` or `tokenSets`'
-          )
-        }
-        if (map.tokenSets && (!(map.tokenSets instanceof Array) || (map.tokenSets as Array<any>).length === 0)) {
-          throw new Error(
-            'Unable to load mapping file: `mapping`.`tokenSets` must be an Array with at least one entry'
-          )
-        }
-        if (map.tokensTheme && (typeof map.tokensTheme !== 'string' || (map.tokensTheme as string).length === 0)) {
-          throw new Error(
-            'Unable to load mapping file: `mapping`.`tokensTheme` must be a non-empty string'
-          )
-        }
-        if (!map.supernovaBrand || typeof map.supernovaBrand !== 'string' || map.supernovaBrand.length === 0) {
-          throw new Error(
-            'Unable to load mapping file: `supernovaBrand` must be a non-empty string'
-          )
-        }
-        if (map.supernovaTheme && (typeof map.supernovaTheme !== 'string' || map.supernovaTheme.length === 0)) {
-          throw new Error(
-            'Unable to load mapping file: `supernovaTheme` may be empty but must be non-empty string if not'
-          )
-        }
-      }
-  
-      if (mapping.settings) {
-        if (typeof mapping.settings !== 'object') {
-          throw new Error('Unable to load mapping file: `settings` must be an object')
-        }
-        if (mapping.settings.hasOwnProperty('dryRun') && typeof mapping.settings.dryRun !== 'boolean') {
-          throw new Error('Unable to load mapping file: `dryRun` must be of boolan type')
-        }
-        if (mapping.settings.hasOwnProperty('verbose') && typeof mapping.settings.verbose !== 'boolean') {
-          throw new Error('Unable to load mapping file: `verbose` must be of boolan type')
-        }
-        if (mapping.settings.hasOwnProperty('preciseCopy') && typeof mapping.settings.preciseCopy !== 'boolean') {
-          throw new Error('Unable to load mapping file: `preciseCopy` must be of boolan type')
-        }
-      }
+
+      let definition = fs.readFileSync(pathToFile, 'utf8')
+      let parsedDefinition = this.parseDefinition(definition) as DTPluginToSupernovaMappingFile
+      return parsedDefinition
+    } catch (error) {
+      throw new Error('Unable to load JSON definition file: ' + error)
     }
-  
-    private processFileToMapping(
-      mapping: DTPluginToSupernovaMappingFile
-    ): {
-      mapping: DTPluginToSupernovaMapPack
-      settings: DTPluginToSupernovaSettings
-    } {
-      let result = new Array<DTPluginToSupernovaMap>()
-      for (let map of mapping.mapping) {
-        result.push({
-          type: map.tokenSets ? DTPluginToSupernovaMapType.set : DTPluginToSupernovaMapType.theme,
-          pluginSets: map.tokenSets ?? null,
-          pluginTheme: map.tokensTheme ?? null,
-          bindToBrand: map.supernovaBrand,
-          bindToTheme: map.supernovaTheme ?? null,
-          nodes: null,
-          processedNodes: null,
-          processedGroups: null
-        })
-      }
-  
-      let settings: DTPluginToSupernovaSettings = {
-        dryRun: mapping.settings?.dryRun ?? false,
-        verbose: mapping.settings?.verbose ?? false,
-        preciseCopy: mapping.settings?.preciseCopy ?? false
-      }
-  
-      return {
-        mapping: result,
-        settings: settings
-      }
+  }
+
+  private weakValidateMapping(mapping: DTPluginToSupernovaMappingFile) {
+    if (
+      !mapping.hasOwnProperty('mode') ||
+      typeof mapping.mode !== 'string' ||
+      (mapping.mode !== 'multi-file' && mapping.mode !== 'single-file')
+    ) {
+      throw new Error(
+        'Unable to load mapping file: `mode` must be provided [single-file or multi-file]`'
+      )
     }
-  
-    // --- --- --- --- --- --- --- --- --- --- --- --- --- --- --- --- --- --- --- --- --- --- --- --- --- ---
-    // MARK: - File Parser
-  
-    private parseDefinition(definition: string): object {
-      try {
-        let object = JSON.parse(definition)
-        if (typeof object !== 'object') {
-          throw new Error(
-            'Invalid Supernova mapping definition JSON file - root level entity must be object'
-          )
-        }
-        return object
-      } catch (error) {
+    if (!mapping.mapping || !(mapping.mapping instanceof Array)) {
+      throw new Error('Unable to load mapping file: `mapping` key must be present and array.')
+    }
+    let mapPack = mapping.mapping
+    for (let map of mapPack) {
+      if (typeof map !== 'object') {
+        throw new Error('Unable to load mapping file: `mapping` must contain objects only')
+      }
+      if (!map.tokenSets && !map.tokensTheme) {
         throw new Error(
-          'Invalid Supernova mapping definition JSON file - file structure invalid'
+          'Unable to load mapping file: `mapping` must contain either `tokensTheme` or `tokenSets`'
+        )
+      }
+      if (map.tokenSets && map.tokensTheme) {
+        throw new Error(
+          'Unable to load mapping file: `mapping` must not contain both `tokensTheme` or `tokenSets`'
+        )
+      }
+      if (map.tokenSets && (!(map.tokenSets instanceof Array) || (map.tokenSets as Array<any>).length === 0)) {
+        throw new Error(
+          'Unable to load mapping file: `mapping`.`tokenSets` must be an Array with at least one entry'
+        )
+      }
+      if (map.tokensTheme && (typeof map.tokensTheme !== 'string' || (map.tokensTheme as string).length === 0)) {
+        throw new Error(
+          'Unable to load mapping file: `mapping`.`tokensTheme` must be a non-empty string'
+        )
+      }
+      if (!map.supernovaBrand || typeof map.supernovaBrand !== 'string' || map.supernovaBrand.length === 0) {
+        throw new Error(
+          'Unable to load mapping file: `supernovaBrand` must be a non-empty string'
+        )
+      }
+      if (map.supernovaTheme && (typeof map.supernovaTheme !== 'string' || map.supernovaTheme.length === 0)) {
+        throw new Error(
+          'Unable to load mapping file: `supernovaTheme` may be empty but must be non-empty string if not'
         )
       }
     }
-  
-  
-    private async loadObjectFile(pathToFile: string): Promise<object> {
-      try {
-        if (!(fs.existsSync(pathToFile) && fs.lstatSync(pathToFile).isFile())) {
-          throw new Error(
-            `Provided token file directory ${pathToFile} is not a file or doesn't exist`
-          )
-        }
-  
-        let definition = fs.readFileSync(pathToFile, 'utf8')
-        let parsedDefinition = this.parseDefinition(definition)
-        return parsedDefinition
-      } catch (error) {
-        throw new Error('Unable to load JSON definition file: ' + error)
+
+    if (mapping.settings) {
+      if (typeof mapping.settings !== 'object') {
+        throw new Error('Unable to load mapping file: `settings` must be an object')
+      }
+      if (mapping.settings.hasOwnProperty('dryRun') && typeof mapping.settings.dryRun !== 'boolean') {
+        throw new Error('Unable to load mapping file: `dryRun` must be of boolan type')
+      }
+      if (mapping.settings.hasOwnProperty('verbose') && typeof mapping.settings.verbose !== 'boolean') {
+        throw new Error('Unable to load mapping file: `verbose` must be of boolan type')
+      }
+      if (mapping.settings.hasOwnProperty('preciseCopy') && typeof mapping.settings.preciseCopy !== 'boolean') {
+        throw new Error('Unable to load mapping file: `preciseCopy` must be of boolan type')
       }
     }
   }
+
+  private processFileToMapping(
+    mapping: DTPluginToSupernovaMappingFile
+  ): {
+    mapping: DTPluginToSupernovaMapPack
+    settings: DTPluginToSupernovaSettings
+  } {
+    let result = new Array<DTPluginToSupernovaMap>()
+    for (let map of mapping.mapping) {
+      result.push({
+        type: map.tokenSets ? DTPluginToSupernovaMapType.set : DTPluginToSupernovaMapType.theme,
+        pluginSets: map.tokenSets ?? null,
+        pluginTheme: map.tokensTheme ?? null,
+        bindToBrand: map.supernovaBrand,
+        bindToTheme: map.supernovaTheme ?? null,
+        nodes: null,
+        processedNodes: null,
+        processedGroups: null
+      })
+    }
+
+    let settings: DTPluginToSupernovaSettings = {
+      dryRun: mapping.settings?.dryRun ?? false,
+      verbose: mapping.settings?.verbose ?? false,
+      preciseCopy: mapping.settings?.preciseCopy ?? false
+    }
+
+    return {
+      mapping: result,
+      settings: settings
+    }
+  }
+
+  // --- --- --- --- --- --- --- --- --- --- --- --- --- --- --- --- --- --- --- --- --- --- --- --- --- ---
+  // MARK: - File Parser
+
+  private parseDefinition(definition: string): object {
+    try {
+      let object = JSON.parse(definition)
+      if (typeof object !== 'object') {
+        throw new Error(
+          'Invalid Supernova mapping definition JSON file - root level entity must be object'
+        )
+      }
+      return object
+    } catch (error) {
+      throw new Error(
+        'Invalid Supernova mapping definition JSON file - file structure invalid'
+      )
+    }
+  }
+
+
+  private async loadObjectFile(pathToFile: string): Promise<object> {
+    try {
+      if (!(fs.existsSync(pathToFile) && fs.lstatSync(pathToFile).isFile())) {
+        throw new Error(
+          `Provided token file directory ${pathToFile} is not a file or doesn't exist`
+        )
+      }
+
+      let definition = fs.readFileSync(pathToFile, 'utf8')
+      let parsedDefinition = this.parseDefinition(definition)
+      return parsedDefinition
+    } catch (error) {
+      throw new Error('Unable to load JSON definition file: ' + error)
+    }
+  }
+}


### PR DESCRIPTION
## Changes (sync-tokens command only)
 - ~~Add `asPlugin` flag (default `false` now) that would~~ make CLI call API to import tokens, instead of using SDK version from package.json. 
 - Same way as TS Plugin does the import. 
 - This will also create data source visible in UI, remove `tokens` scope from Figma sources.
 - There would be no detailed logs in console, just errors (same way as TS Plugin).
 - We will get imported `payloads` from CLI same way as from TS Plugin.
 - Changes default `dev` API endpoint to `v2`

## During V2 API deploy
- We can/will make a API v1 `bff/import` endpoint to error with "Please, update CLI" message. So users would have to update CLI to latest version to sync. 

## After V2 API deploy
- We need to update CLI to use V2 API URL ~~and set `asPlugin` by default to true.~~
- We might need to ask people to update CLI before release, so after release all of them use BE call and do not push old tokens into new model or face error.

## Alternative
- ~~Use v2 SDK instead in `package.json` and a flag which version to use, still change default URLs, still error API v1 `/bff/import`~~
