### PR TITLE
PF-113: Update flags for Token Studio sync

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "@supernovaio/cli",
-    "version": "1.0.5",
+    "version": "1.0.6",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "@supernovaio/cli",
-            "version": "1.0.5",
+            "version": "1.0.6",
             "bundleDependencies": [
                 "@supernova-studio/pulsar-core",
                 "@supernova-studio/simple-parse-github-url",
@@ -12431,6 +12431,14 @@
             },
             "engines": {
                 "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+            }
+        },
+        "node_modules/npm/node_modules/fs-minipass/node_modules/minipass": {
+            "version": "7.0.4",
+            "inBundle": true,
+            "license": "ISC",
+            "engines": {
+                "node": ">=16 || 14 >=14.17"
             }
         },
         "node_modules/npm/node_modules/fs.realpath": {
@@ -28722,6 +28730,12 @@
                     "bundled": true,
                     "requires": {
                         "minipass": "^5.0.0"
+                    },
+                    "dependencies": {
+                        "minipass": {
+                            "version": "7.0.4",
+                            "bundled": true
+                        }
                     }
                 },
                 "fs.realpath": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@supernovaio/cli",
     "description": "Supernova.io Command Line Interface",
-    "version": "1.0.5",
+    "version": "1.0.6",
     "author": "Supernova.io",
     "homepage": "https://supernova.io/",
     "keywords": [
@@ -104,7 +104,7 @@
         "lint": "eslint . --ext .ts --config .eslintrc",
         "postpack": "shx rm -f oclif.manifest.json",
         "prepack": "yarn build && oclif manifest",
-        "test": "DEBUG=* && npm run build && env TS_NODE_PROJECT=\"tsconfig.testing.json\" mocha --require ts-node/register --forbid-only \"test/**/*.test.ts\"",
+        "test": "DEBUG=* && npm run build && env TS_NODE_PROJECT=\"tsconfig.testing.json\" mocha --require ts-node/register --forbid-only \"test/**/sync-tokens.test.ts\"",
         "publish-package": "npm run build && npm run prepack && npm publish --access public && npm run postpack"
     },
     "types": "dist/index.d.ts"

--- a/src/utils/figma-tokens-data-loader.ts
+++ b/src/utils/figma-tokens-data-loader.ts
@@ -193,7 +193,9 @@ export class FigmaTokensDataLoader {
       if (mapping.settings.hasOwnProperty('verbose') && typeof mapping.settings.verbose !== 'boolean') {
         throw new Error('Unable to load mapping file: `verbose` must be of boolan type')
       }
-      if (mapping.settings.hasOwnProperty('preciseCopy') && typeof mapping.settings.preciseCopy !== 'boolean') {
+      if (mapping.settings.hasOwnProperty('preciseCopy')
+        && typeof mapping.settings.preciseCopy !== 'boolean'
+        && typeof mapping.settings.preciseCopy !== "string") {
         throw new Error('Unable to load mapping file: `preciseCopy` must be of boolan type')
       }
     }
@@ -220,6 +222,7 @@ export class FigmaTokensDataLoader {
     }
 
     let settings: DTPluginToSupernovaSettings = {
+      ...(mapping.settings ?? {}),
       dryRun: mapping.settings?.dryRun ?? false,
       verbose: mapping.settings?.verbose ?? false,
       preciseCopy: mapping.settings?.preciseCopy ?? false

--- a/src/utils/figma-tokens-data-loader.ts
+++ b/src/utils/figma-tokens-data-loader.ts
@@ -188,15 +188,15 @@ export class FigmaTokensDataLoader {
         throw new Error('Unable to load mapping file: `settings` must be an object')
       }
       if (mapping.settings.hasOwnProperty('dryRun') && typeof mapping.settings.dryRun !== 'boolean') {
-        throw new Error('Unable to load mapping file: `dryRun` must be of boolan type')
+        throw new Error('Unable to load mapping file: `dryRun` must be of boolean type')
       }
       if (mapping.settings.hasOwnProperty('verbose') && typeof mapping.settings.verbose !== 'boolean') {
-        throw new Error('Unable to load mapping file: `verbose` must be of boolan type')
+        throw new Error('Unable to load mapping file: `verbose` must be of boolean type')
       }
       if (mapping.settings.hasOwnProperty('preciseCopy')
         && typeof mapping.settings.preciseCopy !== 'boolean'
         && typeof mapping.settings.preciseCopy !== "string") {
-        throw new Error('Unable to load mapping file: `preciseCopy` must be of boolan type')
+        throw new Error('Unable to load mapping file: `preciseCopy` must be of boolean or string type')
       }
     }
   }


### PR DESCRIPTION
## Changes

- Support for `"preciseCopy": "keepManualTokens"` flag in `supernova.settings.json`